### PR TITLE
Update Debian packaging to build on openSUSE Build Service

### DIFF
--- a/packaging/debian/README.md
+++ b/packaging/debian/README.md
@@ -1,0 +1,16 @@
+In order to build this on OBS, follow these steps:
+
+1. Create a login for yourself at build.opensuse.org.
+2. Either use your home project or create a subproject, and select
+    Repositories matching those of [home:cvmfs:contrib](https://build.opensuse.org/repositories/home:cvmfs:contrib).  Edit each repository so the
+    Architectures and Additional package repositories match those of
+    home:cvmfs:contrib.
+3. On the Overview tab for the project, select "Branch existing package".
+    Use "home:cvmfs:contrib" as "Name of original project" and 
+    "cvmfs-config-osg" as "Name of package in original project" and select
+    "Create Branch".  It should then build, and you can reload the page
+    until it finishes.  You can also select the "_service" link, click
+    "show latest", and edit the source of the paths to be from
+    different sources if you want to and click "Save".
+4.  To find the built packages, click on Repositories back in the
+    project and select "Go to download repository".

--- a/packaging/debian/README.md
+++ b/packaging/debian/README.md
@@ -9,7 +9,7 @@ In order to build this on OBS, follow these steps:
     Use "home:cvmfs:contrib" as "Name of original project" and 
     "cvmfs-config-osg" as "Name of package in original project" and select
     "Create Branch".  It should then build, and you can reload the page
-    until it finishes.  You can also select the "_service" link, click
+    until it finishes.  You can also select the "\_service" link, click
     "show latest", and edit the source of the paths to be from
     different sources if you want to and click "Save".
 4.  To find the built packages, click on Repositories back in the

--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -8,5 +8,6 @@ Homepage: http://github.conf/opensciencegrid/cvmfs-config-osg
 
 Package: cvmfs-config-osg
 Architecture: all
-Depends: 
+Provides: cvmfs-config
+Conflicts: cvmfs-config
 Description: CernVM File System configuration for OSG

--- a/packaging/debian/cvmfs-config-osg.dsc
+++ b/packaging/debian/cvmfs-config-osg.dsc
@@ -1,0 +1,21 @@
+# created by obsupdate.sh, do not edit by hand
+Debtransform-Tar: cvmfs-config-osg-2.0.tar.gz
+Format: 1.0
+Version: 2.0.3-1
+Binary: cvmfs-config-osg
+Source: cvmfs-config-osg
+Maintainer: Dave Dykstra <dwd@fnal.gov>
+Section: config
+Priority: extra
+Standards-Version: 3.9.3.1
+Build-Depends: debhelper (>= 9) 
+Homepage: http://github.conf/opensciencegrid/cvmfs-config-osg
+
+Package: cvmfs-config-osg
+Architecture: all
+Provides: cvmfs-config
+Conflicts: cvmfs-config
+Description: CernVM File System configuration for OSG
+Files:
+  ffffffffffffffffffffffffffffffff 99999 file1
+  ffffffffffffffffffffffffffffffff 99999 file2

--- a/packaging/debian/obsupdate.sh
+++ b/packaging/debian/obsupdate.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# update $PKG.dsc
+# That file is used by build.opensuse.org's Open Build Service
+# After the file is updated, it needs to be separately committed to git.
+
+HERE="`dirname $0`"
+ME="`basename $0`"
+PKG="`sed -n 's/^Source: //p' control`"
+SPECFILE="../redhat/$PKG.spec"
+VERSION="$(grep ^Version: $SPECFILE | awk '{print $2}')"
+RPMREL="$(grep '^%define release_prefix' $SPECFILE | awk '{print $3}')"
+if [ -z "$RPMREL" ]; then
+    RPMREL="$(grep '^Release:' $SPECFILE | awk '{print $2}' | cut -d% -f1)"
+fi
+# if the version is current, increment the release number, else choose 1
+DEBREL="`sed -n "s/^Version: ${VERSION}\.${RPMREL}//p" $PKG.dsc 2>/dev/null`"
+if [ -z "$DEBREL" ]; then
+    DEBREL=1
+else
+    let DEBREL+=1
+fi
+(
+echo "# created by $ME, do not edit by hand"
+# The following two lines are OBS "magic" to use the tarball from the rpm
+echo "Debtransform-Tar: ${PKG}-${VERSION}.tar.gz"
+#echo "Debtransform-Files-Tar: "
+echo "Format: 1.0"
+echo "Version: ${VERSION}.${RPMREL}-${DEBREL}"
+echo "Binary: $PKG"
+cat control
+echo "Files:"
+echo "  ffffffffffffffffffffffffffffffff 99999 file1"
+echo "  ffffffffffffffffffffffffffffffff 99999 file2"
+) > $PKG.dsc
+#
+echo "Updated $PKG.dsc"

--- a/packaging/debian/obsupdate.sh
+++ b/packaging/debian/obsupdate.sh
@@ -13,7 +13,7 @@ if [ -z "$RPMREL" ]; then
     RPMREL="$(grep '^Release:' $SPECFILE | awk '{print $2}' | cut -d% -f1)"
 fi
 # if the version is current, increment the release number, else choose 1
-DEBREL="`sed -n "s/^Version: ${VERSION}\.${RPMREL}//p" $PKG.dsc 2>/dev/null`"
+DEBREL="`sed -n "s/^Version: ${VERSION}\.${RPMREL}-//p" $PKG.dsc 2>/dev/null`"
 if [ -z "$DEBREL" ]; then
     DEBREL=1
 else


### PR DESCRIPTION
This PR makes cvmfs-config-osg buildable for Debian/Ubuntu on the openSUSE Build Service (OBS). This will become part of the new "cvmfs-contrib" repository maintained there (by me).  There will be both Debian/Ubuntu and CentOS versions of the cvmfs-contrib repository, but cvmfs-config-osg is only needed there for Debian, since the OSG doesn't have its own corresponding Debian repository.  This PR also defines cvmfs-config-osg as a Debian cvmfs-config virtual package by adding both Provides and Conflicts of cvmfs-config.

I have done a [test build](https://build.opensuse.org/package/show/home:drdaved:cvmfs-contrib/cvmfs-config-osg) of this package on OBS using the package files from this PR.