### PR TITLE
Stop using deprecated Debian package priority

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -1,7 +1,7 @@
 Source: cvmfs-config-osg
 Maintainer: Dave Dykstra <dwd@fnal.gov>
 Section: utils
-Priority: extra
+Priority: optional
 Standards-Version: 3.9.6
 Build-Depends: debhelper (>= 9)
 Homepage: http://github.com/opensciencegrid/cvmfs-config-osg


### PR DESCRIPTION
The debian package priority `extra` [has been deprecated](https://www.debian.org/doc/debian-policy/#priorities) in favor of `optional`. Seems wise enough to migrate to using it instead. This change was made sometime between version 3.9.6 of the policy and the current 4.1.x. But `optional` is valid and reasonable for both versions.

Came up while packaging up another tool.