### PR TITLE
Apply config repo improvements to the config repo's own configuration

### DIFF
--- a/60-osg.conf
+++ b/60-osg.conf
@@ -8,4 +8,4 @@ CVMFS_KEYS_DIR=/etc/cvmfs/keys/opensciencegrid.org
 CVMFS_USE_GEOAPI=yes
 CVMFS_CONFIG_REPOSITORY=config-osg.opensciencegrid.org
 CVMFS_CONFIG_REPO_REQUIRED=yes
-CVMFS_FALLBACK_PROXY="http://cvmfsbproxy.cern.ch:3126;http://cvmfsbproxy.fnal.gov:3126"
+CVMFS_FALLBACK_PROXY="http://cvmfsbproxy.fnal.gov:3126;http://cvmfsbproxy.cern.ch:3126"

--- a/config-osg.opensciencegrid.org.conf
+++ b/config-osg.opensciencegrid.org.conf
@@ -1,6 +1,26 @@
-if [ "$CVMFS_HTTP_PROXY" = "DIRECT" ] || [ "$CVMFS_HTTP_PROXY" = "auto;DIRECT" ]; then
-    CVMFS_SERVER_URL="http://s1bnl-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1fnal-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1osggoc-cvmfs.openhtc.io/cvmfs/@fqrn@"
+# Other than setting the CVMFS_SERVER_URL, this file copies the logic from
+#  common.conf in the configuration repository
+
+if [ "$CVMFS_CLIENT_PROFILE" = "single" ]; then
+  if [ "$CVMFS_HTTP_PROXY" = "" ]; then
+    CVMFS_HTTP_PROXY="auto;DIRECT"
+  fi
+fi
+
+if [ -z "$CVMFS_USE_CDN" ]; then
+  if [ "$CVMFS_HTTP_PROXY" = "DIRECT" ] || [ "$CVMFS_HTTP_PROXY" = "auto;DIRECT" ]; then
+    CVMFS_USE_CDN=yes
+  fi
+fi
+
+if [ "$CVMFS_USE_CDN" = "yes" ] || [ "$CVMFS_CLIENT_PROFILE" = "custom" ]; then
     CVMFS_FALLBACK_PROXY=""
+fi
+
+####
+
+if [ "$CVMFS_USE_CDN" = "yes" ]; then
+    CVMFS_SERVER_URL="http://s1bnl-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1fnal-cvmfs.openhtc.io/cvmfs/@fqrn@;http://s1osggoc-cvmfs.openhtc.io/cvmfs/@fqrn@"
 else
     CVMFS_SERVER_URL="http://cvmfs-s1bnl.opensciencegrid.org:8000/cvmfs/@fqrn@;http://cvmfs-s1fnal.opensciencegrid.org:8000/cvmfs/@fqrn@;http://cvmfs-s1goc.opensciencegrid.org:8000/cvmfs/@fqrn@"
 fi

--- a/config-osg.opensciencegrid.org.conf
+++ b/config-osg.opensciencegrid.org.conf
@@ -1,5 +1,13 @@
 # Other than setting the CVMFS_SERVER_URL, this file copies the logic from
-#  common.conf in the configuration repository
+#  default.conf and common.conf in the configuration repository
+
+if [ -z "$CVMFS_PAC_URLS" ] || [ "$CVMFS_PAC_URLS" = "http://wpad/wpad.dat" ]; then
+  if [ "$(($$ % 2))" -eq 1 ]; then
+    CVMFS_PAC_URLS="http://grid-wpad/wpad.dat;http://wpad/wpad.dat;http://cernvm-wpad.fnal.gov/wpad.dat;http://cernvm-wpad.cern.ch/wpad.dat"
+  else
+    CVMFS_PAC_URLS="http://grid-wpad/wpad.dat;http://wpad/wpad.dat;http://cernvm-wpad.cern.ch/wpad.dat;http://cernvm-wpad.fnal.gov/wpad.dat"
+  fi
+fi
 
 if [ "$CVMFS_CLIENT_PROFILE" = "single" ]; then
   if [ "$CVMFS_HTTP_PROXY" = "" ]; then

--- a/debian/cvmfs-config-osg.dsc
+++ b/debian/cvmfs-config-osg.dsc
@@ -1,7 +1,7 @@
 # created by obsupdate.sh, do not edit by hand
-Debtransform-Tar: cvmfs-config-osg-2.4.tar.gz
+Debtransform-Tar: cvmfs-config-osg-2.5.tar.gz
 Format: 1.0
-Version: 2.4.4
+Version: 2.5.1
 Binary: cvmfs-config-osg
 Source: cvmfs-config-osg
 Maintainer: Dave Dykstra <dwd@fnal.gov>

--- a/rpm/cvmfs-config-osg.spec
+++ b/rpm/cvmfs-config-osg.spec
@@ -1,7 +1,7 @@
 Summary: CernVM File System OSG Configuration and Public Keys
 Name: cvmfs-config-osg
-Version: 2.4
-Release: 4%{?dist}
+Version: 2.5
+Release: 1%{?dist}
 # download with:
 # $ curl -L -o cvmfs-config-osg-%{version}.tar.gz \
 #   https://github.com/opensciencegrid/cvmfs-config-osg/archive/v%{version}.tar.gz
@@ -40,6 +40,13 @@ make install-redhat DESTDIR=$RPM_BUILD_ROOT
 %config %{_sysconfdir}/cvmfs/config.d/*
 
 %changelog
+* Mon Oct 12 2020 Dave Dykstra <dwd@fnal.gov> - 2.5-1
+- Update the configuration for the config repo to apply all the logic
+  from the config repo's common.conf.  That is, support USE_CVMFS_CDN
+  and CVMFS_CLIENT_PROFILE.
+- Reverse the order of the fallback proxies because of the bug in 
+  https://sft.its.cern.ch/jira/browse/CVM-1920
+
 * Fri Mar 27 2020 Dave Dykstra <dwd@fnal.gov> - 2.4-4
 - Skipped release 2.4-2 and 2.4-3 to make consistent with cvmfs-config-egi.
 - Change Conflicts: cvmfs-config-default to Obsoletes: to make it

--- a/rpm/cvmfs-config-osg.spec
+++ b/rpm/cvmfs-config-osg.spec
@@ -42,8 +42,9 @@ make install-redhat DESTDIR=$RPM_BUILD_ROOT
 %changelog
 * Mon Oct 12 2020 Dave Dykstra <dwd@fnal.gov> - 2.5-1
 - Update the configuration for the config repo to apply all the logic
-  from the config repo's common.conf.  That is, support USE_CVMFS_CDN
-  and CVMFS_CLIENT_PROFILE.
+  from the config repo's default.conf and common.conf.  That is, support
+  USE_CVMFS_CDN and CVMFS_CLIENT_PROFILE and set default CVMFS_PAC_URLS
+  covering the WLCG Web Proxy Auto Discovery.
 - Reverse the order of the fallback proxies because of the bug in 
   https://sft.its.cern.ch/jira/browse/CVM-1920
 


### PR DESCRIPTION
The OSG cvmfs configuration repo now supports a few new features for all repositories, except it can't apply to the configuration repository itself.  Copy those new features there, in the rpm. 

See also [SOFTWARE-4296](https://opensciencegrid.atlassian.net/browse/SOFTWARE-4296)